### PR TITLE
Fix Github URLs to go to the website rather than the API endpoints

### DIFF
--- a/syte/static/templates/github-profile-view.html
+++ b/syte/static/templates/github-profile-view.html
@@ -31,14 +31,14 @@
   <ul class="profile-repos">
     {{#each repos}}
     <li>
-    <a href="{{ url }}" class="profile-repo-name">{{ name }}</a>
+    <a href="{{ html_url }}" class="profile-repo-name">{{ name }}</a>
     <p class="profile-repo-text">
       {{ description }}
     </p>
     <ul class="profile-repo-stats">
       <li>{{ language }}</li>
-      <li><a href="{{ url }}/watchers" class="profile-watchers">{{ watchers }}</a></li>
-      <li><a href="{{ url }}/network" class="profile-forks">{{ forks }}</a></li>
+      <li><a href="{{ html_url }}/watchers" class="profile-watchers">{{ watchers }}</a></li>
+      <li><a href="{{ html_url }}/network" class="profile-forks">{{ forks }}</a></li>
     </ul>
     </li>
     {{/each}}


### PR DESCRIPTION
I'm guessing this was a change from Github API version 3, but the Github links are all api.github.com, so they open a page with JSON.

Just changed the template to use html_url instead of url.
