### PR TITLE
Fix a few places where we could get errors from bad last.fm data

### DIFF
--- a/syte/static/js/components/lastfm.js
+++ b/syte/static/js/components/lastfm.js
@@ -23,18 +23,26 @@ function setupLastfm(url, el) {
      * language itself so cannot reference '#text' easily in the template. */
      Handlebars.registerHelper('text', function(obj) {
         try {
-          return obj['#text'];
+            return obj['#text'];
         } catch (err) {
             return '';
         }
      });
 
      Handlebars.registerHelper('image_url', function(obj) {
-        return obj[0]['#text'];
+        try {
+            return obj[0]['#text'];
+        } catch (err) {
+            return '';
+        }
      });
 
      Handlebars.registerHelper('avatar_url', function(obj) {
-        return obj[1]['#text'];
+        try {
+            return obj[1]['#text'];
+        } catch (err) {
+            return '';
+        }
      });
 
      require(["json!/lastfm/" + username, "text!templates/lastfm-profile.html"],
@@ -51,7 +59,16 @@ function setupLastfm(url, el) {
             lastfm_data.user_info.user.formatted_register_date = moment(lastfm_data.user_info.user.registered['#text'], 'YYYY-MM-DD HH:mm').format('MM/DD/YYYY');
             
             $.each(lastfm_data.recenttracks.recenttracks.track, function(i, t) {
-                t.formatted_date = moment.utc(t.date['#text'], 'DD MMM YYYY, HH:mm').fromNow();
+                // Lastfm can be really finicky with data and return garbage if
+                // the track is currently playing
+                try {
+                    date = t.date['#text']
+                } catch (err) {
+                    t.formatted_date = 'Now Playing';
+                    return true; // equivalent to 'continue' with a normal for loop
+                }
+
+                t.formatted_date = moment.utc(date, 'DD MMM YYYY, HH:mm').fromNow();
             });
 
             $(template(lastfm_data)).modal().on('hidden', function () {


### PR DESCRIPTION
- I see lots of 'missing' data when a track is currently playing.  Last.fm
  seems to return some of the data, but the recent track 'date' is empty when
  the track is playing and hasn't been 'scrobbled' yet.
  - You must listen to at least 50% of a song before it really counts towards
    your scrobbles/stats.  However, while listening the data is returned
    without the date.
