### PR TITLE
Bug fix: Opera does not support window.matchMedia.

### DIFF
--- a/syte/static/js/components/mobile.js
+++ b/syte/static/js/components/mobile.js
@@ -1,9 +1,11 @@
 
 var isMobileView = false;
-var mediaQuery = window.matchMedia("(max-width:799px)");
 
-if (mediaQuery.matches) {
-    isMobileView = true;
+if (typeof window.matchMedia !== 'undefined') {
+    var mediaQuery = window.matchMedia("(max-width:799px)");
+    if (mediaQuery.matches) {
+        isMobileView = true;
+    }
 }
 
 $(function() {


### PR DESCRIPTION
The latest Opera, version 12.01 (rendering engine Presto 2.10), does not support `window.matchMedia` [1].
The fix simply checks if `window.matchMedia` is defined or not.

`window.matchMedia` is supported from Presto 2.11, which is not used in a stable version of Opera yet [2].
- [1] http://www.opera.com/docs/specs/presto2.10/css/cssom/
- [2] http://www.opera.com/docs/specs/presto2.11/css/cssom/
