### PR TITLE
Fix alternative text on alexmeswarb readme-image link in README.mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can use, reproduce and do whatever you want with syte but I would like you t
 [![damilare](https://github.com/rigoneri/syte/blob/master/readme-imgs/damilare.png?raw=true)](http://dami.me)
 [![eventh](https://github.com/rigoneri/syte/blob/master/readme-imgs/eventh.png?raw=true)](http://eventh.herokuapp.com)
 [![clayferris](https://github.com/rigoneri/syte/blob/master/readme-imgs/clayferris.png?raw=true)](http://claytonferris.com)
-[![eventh](https://github.com/rigoneri/syte/blob/master/readme-imgs/ameswarb.png?raw=true)](http://alexmeswarb.com)
+[![alexmeswarb](https://github.com/rigoneri/syte/blob/master/readme-imgs/ameswarb.png?raw=true)](http://alexmeswarb.com)
 [![pranayairan](https://github.com/rigoneri/syte/blob/master/readme-imgs/pranayairan.png?raw=true)](http://pranayairan.herokuapp.com)
 
 

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import os
 import sys
+
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "syte.settings")


### PR DESCRIPTION
I think @ameswarb committed a minor copy-paste error,
so I changed "eventh" to "alexmeswarb".

I also added a utf-8 encoding tag to manage.py, which I
had forgotten 3 days ago.
