### PR TITLE
Fix #119, github usernames may contain hyphens.

### DIFF
--- a/syte/urls.py
+++ b/syte/urls.py
@@ -28,7 +28,7 @@ if settings.GITHUB_OAUTH_ENABLED:
 
 if settings.GITHUB_INTEGRATION_ENABLED:
     urlpatterns += patterns('',
-        url(r'^github/(?P<username>\w+)/?$', 'syte.views.github.github'),
+        url(r'^github/(?P<username>[\-\w]+)/?$', 'syte.views.github.github'),
     )
 
 #Bitbucket Integration


### PR DESCRIPTION
Fix: Syte would give a 404 if the github username contained a hyphen.
Solves issue #119.
