### PR TITLE
Resolved coloring of active menu list item

### DIFF
--- a/syte/static/less/styles.less
+++ b/syte/static/less/styles.less
@@ -70,7 +70,7 @@
       border-right: 0;
       text-shadow: none;
     }
-    .sel { border-right: 6px solid @adjacent-color;  }
+    .sel a { border-right: 6px solid @adjacent-color;  }
   }
 
   .spinner {


### PR DESCRIPTION
When you hover active menu link, the border on the right goes down to the next menu list item, outside the background of anchor. The right border for active link item should be defined for anchor, not for the list item.
