### PR TITLE
fix fade-large ==> fade.large in styles-mobile.less

### DIFF
--- a/syte/static/less/styles-mobile.less
+++ b/syte/static/less/styles-mobile.less
@@ -129,9 +129,9 @@
     z-index: 4000;
     top: 45px;
 
-    &.fade-large { width: 100%; }
+    &.fade.large { width: 100%; }
 
-    &.fade.in, &.fade-large.in { left: 0; }
+    &.fade.in { left: 0; }
   }
 
   .profile.twitter, .profile.github, .profile.bitbucket, .profile.dribbble, .profile.instagram {


### PR DESCRIPTION
Accidentally forgot to change styles-mobile.less when changing .fade-large to .fade.large -- should fix the Instagram and Dribbble modal width being too wide when viewed on mobile browsers.
