### PR TITLE
The npmjs.org link has moved (https)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Compressing static files like CSS and JS are done using [Node.js](http://nodejs.
 In order to get there you need to first install [node.js](http://nodejs.org/), they have automatic installers which makes installation really easy. Then you need to install [Node Package Manager (npm)](http://npmjs.org/) by running the following command:
 
 ```
-curl http://npmjs.org/install.sh | sudo sh
+curl https://npmjs.org/install.sh | sudo sh
 ```
 
 After npm is installed you need to install two node packages `less` and `uglify-js`. To do that run the following commands:


### PR DESCRIPTION
Change the link to https rather than http, otherwise you get this:

(syte)manavo:~ manavo$ curl http://npmjs.org/install.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    85    0    85    0     0    222      0 --:--:-- --:--:-- --:--:--   611
sh: line 1: syntax error near unexpected token `newline'
sh: line 1:`<html>Moved: <a href="https://npmjs.org/install.sh">https://npmjs.org/install.sh</a>'
