### PR TITLE
The npmjs.org link has moved (https)

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@ $ workon syte
 
 <p>In order to get there you need to first install <a href="http://nodejs.org/">node.js</a>, they have automatic installers which makes installation really easy. Then you need to install <a href="http://npmjs.org/">Node Package Manager (npm)</a> by running the following command:</p>
 
-<pre><code>curl http://npmjs.org/install.sh | sudo sh
+<pre><code>curl https://npmjs.org/install.sh | sudo sh
 </code></pre>
 
 <p>After npm is installed you need to install two node packages <code>less</code> and <code>uglify-js</code>. To do that run the following commands:</p>


### PR DESCRIPTION
Change the link to https rather than http, otherwise you get this:

(syte)manavo:~ manavo$ curl http://npmjs.org/install.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    85    0    85    0     0    222      0 --:--:-- --:--:-- --:--:--   611
sh: line 1: syntax error near unexpected token `newline'
sh: line 1:`<html>Moved: <a href="https://npmjs.org/install.sh">https://npmjs.org/install.sh</a>'
