### PR TITLE
Added background and image size for newer Foursquare venue URLs.

### DIFF
--- a/syte/static/js/components/foursquare.js
+++ b/syte/static/js/components/foursquare.js
@@ -1,4 +1,3 @@
-
 function setupFoursquare(el) {
   var href = el.href;
 
@@ -33,7 +32,7 @@ function setupFoursquare(el) {
             if (c.venue) {
               var category =  c.venue['categories'][0];
               if (category) {
-                var prefix = category.icon.prefix;
+                var prefix = category.icon.prefix + 'bg_32';
                 if (prefix.substring(prefix.length-1) == '_') {
                   prefix = prefix.substring(0, prefix.length - 1);
                 }


### PR DESCRIPTION
Foursquare venue images are broken and now require background ('_bg') and image size ('_32') parameters.

Updated string interpolation to take care of this; resolves #231.
